### PR TITLE
Run CI for current go versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ workflows:
   build:
     jobs:
       - build-latest
-      - build-1.12
-      - build-1.13
       - build-1.14
       - build-1.15
   scheduled:
@@ -18,8 +16,6 @@ workflows:
                 - master
     jobs:
       - build-latest
-      - build-1.12
-      - build-1.13
       - build-1.14
       - build-1.15
 
@@ -50,16 +46,6 @@ jobs:
                     go get mvdan.cc/gofumpt/gofumports
                     gofumports -d .
                     [ -z "$(gofumports -l .)" ]
-
-  build-1.12:
-    <<: *build-template
-    docker:
-      - image: circleci/golang:1.12
-
-  build-1.13:
-    <<: *build-template
-    docker:
-      - image: circleci/golang:1.13
 
   build-1.14:
     <<: *build-template


### PR DESCRIPTION
Newest version of staticcheck does not run with go 1.12 anymore.